### PR TITLE
Inject values to record when buffered same as non-buffered

### DIFF
--- a/lib/fluent/plugin/out_mqtt.rb
+++ b/lib/fluent/plugin/out_mqtt.rb
@@ -108,6 +108,7 @@ module Fluent::Plugin
     end
 
     def format(tag, time, record)
+      record = inject_values_to_record(tag, time, record)
       [tag, time, record].to_msgpack
     end
 


### PR DESCRIPTION
When users selected buffered type, plugin should inject values to record same as non-buffered case. 