### PR TITLE
[WIP]enable security and tls option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The default MQTT topic is "#". Configurable options are the following:
 
 - **host**: IP address of MQTT broker
 - **port**: Port number of MQTT broker
+- **client_id**: Client ID that to connect to MQTT broker
 - **format** (mandatory): Input parser can be chosen, e.g. json, xml
   - In order to use xml format, you need to install [fluent-plugin-xml-parser](https://github.com/toyokazu/fluent-plugin-xml-parser).
   - Default time_key field for json format is 'time'

--- a/lib/fluent/plugin/mqtt_proxy.rb
+++ b/lib/fluent/plugin/mqtt_proxy.rb
@@ -10,6 +10,8 @@ module Fluent::Plugin
       base.config_param :host, :string, default: '127.0.0.1'
       base.desc 'The port to connect to.'
       base.config_param :port, :integer, default: MQTT_PORT
+      base.desc 'Client ID of MQTT Connection'
+      base.config_param :client_id, :string, default: nil
       base.desc 'Specify keep alive interval.'
       base.config_param :keep_alive, :integer, default: 15
       base.desc 'Specify initial connection retry interval.'
@@ -51,6 +53,7 @@ module Fluent::Plugin
       opts = {
         host: @host,
         port: @port,
+        client_id: @client_id,
         keep_alive: @keep_alive
       }
       opts[:username] = @security.username if @security.to_h.has_key?(:username)

--- a/lib/fluent/plugin/mqtt_proxy.rb
+++ b/lib/fluent/plugin/mqtt_proxy.rb
@@ -21,19 +21,19 @@ module Fluent::Plugin
 
       base.config_section :security, required: false, multi: false do
         ### User based authentication
-        base.desc 'The username for authentication'
-        base.config_param :username, :string, default: nil
-        base.desc 'The password for authentication'
-        base.config_param :password, :string, default: nil
-        base.desc 'Use TLS or not.'
-        base.config_param :use_tls, :bool, default: nil
-        base.config_section :tls, required: false, multi: true do
-          base.desc 'Specify TLS ca file.'
-          base.config_param :ca_file, :string, default: nil
-          base.desc 'Specify TLS key file.'
-          base.config_param :key_file, :string, default: nil
-          base.desc 'Specify TLS cert file.'
-          base.config_param :cert_file, :string, default: nil
+        desc 'The username for authentication'
+        config_param :username, :string, default: nil
+        desc 'The password for authentication'
+        config_param :password, :string, default: nil
+        desc 'Use TLS or not.'
+        config_param :use_tls, :bool, default: nil
+        config_section :tls, required: false, multi: false do
+          desc 'Specify TLS ca file.'
+          config_param :ca_file, :string, default: nil
+          desc 'Specify TLS key file.'
+          config_param :key_file, :string, default: nil
+          desc 'Specify TLS cert file.'
+          config_param :cert_file, :string, default: nil
         end
       end
     end
@@ -53,9 +53,9 @@ module Fluent::Plugin
         port: @port,
         keep_alive: @keep_alive
       }
-      opts[:username] = @security.username if @security.respond_to?(:username)
-      opts[:password] = @security.password if @security.respond_to?(:password)
-      if @security.respond_to?(:use_tls) && @security.use_tls
+      opts[:username] = @security.username if @security.to_h.has_key?(:username)
+      opts[:password] = @security.password if @security.to_h.has_key?(:password)
+      if @security.to_h.has_key?(:use_tls) && @security.use_tls
         opts[:ssl] = @security.use_tls
         opts[:ca_file] = @security.tls.ca_file
         opts[:cert_file] = @security.tls.cert_file

--- a/lib/fluent/plugin/out_mqtt.rb
+++ b/lib/fluent/plugin/out_mqtt.rb
@@ -12,6 +12,7 @@ module Fluent::Plugin
 
     helpers :compat_parameters, :formatter, :inject
 
+
     desc 'Topic rewrite matching pattern.'
     config_param :topic_rewrite_pattern, :string, default: nil
     desc 'Topic rewrite replacement string.'

--- a/test/plugin/test_in_mqtt.rb
+++ b/test/plugin/test_in_mqtt.rb
@@ -11,7 +11,7 @@ class MqttInputTest < Test::Unit::TestCase
   CONFIG = %[
   ]
 
-  def create_driver(conf = CONFIG, opts = {}) 
+  def create_driver(conf = CONFIG, opts = {})
     Fluent::Test::Driver::Input.new(Fluent::Plugin::MqttInput, opts: opts).configure(conf)
   end
 
@@ -24,9 +24,24 @@ class MqttInputTest < Test::Unit::TestCase
             @type json
             time_format %FT%T%:z
           </parse>
+          <security>
+            use_tls true
+            <tls>
+              ca_file /cert/cacert.pem
+              key_file /cert/private.key
+              cert_file /cert/cert.pem
+            </tls>
+          </security>
+
       ]
       assert_equal '127.0.0.1', d.instance.host
       assert_equal 1300, d.instance.port
+
+      assert_equal true, d.instance.security.use_tls
+      assert_equal '/cert/cacert.pem', d.instance.security.tls.ca_file
+      assert_equal '/cert/private.key', d.instance.security.tls.key_file
+      assert_equal '/cert/cert.pem', d.instance.security.tls.cert_file
+
     end
   end
 end

--- a/test/plugin/test_in_mqtt.rb
+++ b/test/plugin/test_in_mqtt.rb
@@ -20,6 +20,7 @@ class MqttInputTest < Test::Unit::TestCase
       d = create_driver %[
           host 127.0.0.1
           port 1300
+          client_id aa-bb-cc-dd
           <parse>
             @type json
             time_format %FT%T%:z
@@ -36,6 +37,7 @@ class MqttInputTest < Test::Unit::TestCase
       ]
       assert_equal '127.0.0.1', d.instance.host
       assert_equal 1300, d.instance.port
+      assert_equal 'aa-bb-cc-dd', d.instance.client_id
 
       assert_equal true, d.instance.security.use_tls
       assert_equal '/cert/cacert.pem', d.instance.security.tls.ca_file

--- a/test/plugin/test_out_mqtt.rb
+++ b/test/plugin/test_out_mqtt.rb
@@ -11,7 +11,7 @@ class MqttOutputTest < Test::Unit::TestCase
   CONFIG = %[
   ]
 
-  def create_driver(conf = CONFIG, opts = {}) 
+  def create_driver(conf = CONFIG, opts = {})
     Fluent::Test::Driver::Output.new(Fluent::Plugin::MqttOutput, opts: opts).configure(conf)
   end
 
@@ -23,9 +23,26 @@ class MqttOutputTest < Test::Unit::TestCase
         <format>
           @type json
         </format>
+        <monitor>
+          send_time true
+        </monitor>
+        <security>
+          use_tls true
+          <tls>
+            ca_file /cert/cacert.pem
+            key_file /cert/private.key
+            cert_file /cert/cert.pem
+          </tls>
+        </security>
       ]
       assert_equal '127.0.0.1', d.instance.host
       assert_equal 1300, d.instance.port
-    end
+      assert_equal true, d.instance.monitor.send_time
+
+      assert_equal true, d.instance.security.use_tls
+      assert_equal '/cert/cacert.pem', d.instance.security.tls.ca_file
+      assert_equal '/cert/private.key', d.instance.security.tls.key_file
+      assert_equal '/cert/cert.pem', d.instance.security.tls.cert_file
+   end
   end
 end

--- a/test/plugin/test_out_mqtt.rb
+++ b/test/plugin/test_out_mqtt.rb
@@ -20,6 +20,7 @@ class MqttOutputTest < Test::Unit::TestCase
       d = create_driver %[
         host 127.0.0.1
         port 1300
+        client_id aa-bb-cc-dd
         <format>
           @type json
         </format>
@@ -38,6 +39,7 @@ class MqttOutputTest < Test::Unit::TestCase
       assert_equal '127.0.0.1', d.instance.host
       assert_equal 1300, d.instance.port
       assert_equal true, d.instance.monitor.send_time
+      assert_equal 'aa-bb-cc-dd', d.instance.client_id
 
       assert_equal true, d.instance.security.use_tls
       assert_equal '/cert/cacert.pem', d.instance.security.tls.ca_file


### PR DESCRIPTION
- Removed `base.` prefix in the config section of included trigger because we don't need it in the `base.config_section` context.
- Disable multi option in `tls` section .
- Replase `respond_to?` to `to_h.has_key?` because `Fluent::Config::Section` does not respond to config filed name as defined [here](https://github.com/fluent/fluentd/blob/master/lib/fluent/config/section.rb#L82)
- Add `client_id` option of MQTT connection
- Added unit tests
  
This will solves #5 