### PR TITLE
Add raises_write_error option that does not try to reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ For fluent-plugin-mqtt-io ~> v0.3.0
 
 The options are basically the same as Input Plugin except for "format" and "bulk_trans" (only for Input). Additional options for Output Plugin are the following.
 
+- **raises_write_error**: If set true, raises exception without reconnect when it had some error while publishing. Default is false.
 - **time_key**: An attribute name used for timestamp field genarated from fluentd time field. Default is nil (omitted).
   If this option is omitted, timestamp field is not appended to the output record.
 - **time_format**: Output format of timestamp field. Default is ISO8601. You can specify your own format by using TimeParser.

--- a/test/plugin/test_out_mqtt.rb
+++ b/test/plugin/test_out_mqtt.rb
@@ -21,6 +21,7 @@ class MqttOutputTest < Test::Unit::TestCase
         host 127.0.0.1
         port 1300
         client_id aa-bb-cc-dd
+        raises_write_error true
         <format>
           @type json
         </format>
@@ -40,6 +41,7 @@ class MqttOutputTest < Test::Unit::TestCase
       assert_equal 1300, d.instance.port
       assert_equal true, d.instance.monitor.send_time
       assert_equal 'aa-bb-cc-dd', d.instance.client_id
+      assert_equal true, d.instance.raises_write_error
 
       assert_equal true, d.instance.security.use_tls
       assert_equal '/cert/cacert.pem', d.instance.security.tls.ca_file


### PR DESCRIPTION
Added `raises_write_error` to the out plugin with that the plugin does not try to reconnect after failure of publishing.
We need this option because fluentd's buffering option works only when out plugin's `write` option fails. With current reconnect mechanism, fluentd's buffer feature does not work.