### PR TITLE
support retain and qos options

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ For fluent-plugin-mqtt-io ~> v0.3.0
 ```
 
 The options are basically the same as Input Plugin except for "format" and "bulk_trans" (only for Input). Additional options for Output Plugin are the following.
-
+- **qos**: Quality of Service (QoS) for message publishing, 0 or 1 is valid. 2 is not supported by mqtt client. Default is 1.
+- **retain**: If set true the broker will keep the message even after sending it to all current subscribers. Default is false
 - **time_key**: An attribute name used for timestamp field genarated from fluentd time field. Default is nil (omitted).
   If this option is omitted, timestamp field is not appended to the output record.
 - **time_format**: Output format of timestamp field. Default is ISO8601. You can specify your own format by using TimeParser.

--- a/lib/fluent/plugin/mqtt_proxy.rb
+++ b/lib/fluent/plugin/mqtt_proxy.rb
@@ -110,6 +110,8 @@ module Fluent::Plugin
         retry_connect(e, "System call error occurs.")
       rescue StandardError=> e
         retry_connect(e, "The other error occurs.")
+      rescue MQTT::NotConnectedException=> e
+        retry_connect(e, "MQTT not connected exception occurs.")
       end
     end
 

--- a/lib/fluent/plugin/out_mqtt.rb
+++ b/lib/fluent/plugin/out_mqtt.rb
@@ -18,6 +18,11 @@ module Fluent::Plugin
     desc 'Topic rewrite replacement string.'
     config_param :topic_rewrite_replacement, :string, default: nil
 
+    desc 'Retain option which publishing'
+    config_param :retain, :bool, default: false
+    desc 'QoS option which publishing'
+    config_param :qos, :integer, default: 1
+
     config_section :format do
       desc 'The format to publish'
       config_param :@type, :string, default: 'single_value'
@@ -139,7 +144,12 @@ module Fluent::Plugin
       chunk.each do |tag, time, record|
         rescue_disconnection do
           log.debug "MqttOutput#write: #{rewrite_tag(rewrite_tag(tag))}, #{time}, #{add_send_time(record)}"
-          @client.publish(rewrite_tag(tag), @formatter.format(tag, time, add_send_time(record)))
+          @client.publish(
+            rewrite_tag(tag),
+            @formatter.format(tag, time, add_send_time(record)),
+            @retain,
+            @qos
+          )
         end
       end
     end

--- a/test/plugin/test_out_mqtt.rb
+++ b/test/plugin/test_out_mqtt.rb
@@ -21,6 +21,8 @@ class MqttOutputTest < Test::Unit::TestCase
         host 127.0.0.1
         port 1300
         client_id aa-bb-cc-dd
+        retain true
+        qos 2
         <format>
           @type json
         </format>
@@ -39,6 +41,8 @@ class MqttOutputTest < Test::Unit::TestCase
       assert_equal '127.0.0.1', d.instance.host
       assert_equal 1300, d.instance.port
       assert_equal true, d.instance.monitor.send_time
+      assert_equal true, d.instance.retain
+      assert_equal 2, d.instance.qos
       assert_equal 'aa-bb-cc-dd', d.instance.client_id
 
       assert_equal true, d.instance.security.use_tls


### PR DESCRIPTION
Added qos and retain options, especially qos is important parameter for users.
Default value of qos is set to 1, at least once message delivery.