### PR TITLE
Feature/add ha hosts and topic with qos

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,12 @@ When using security options, specify them in security section; for example:
 The default MQTT topic is "#". Configurable options are the following:
 
 - **host**: IP address of MQTT broker
+- **ha_hosts**: IP addresses of highly available MQTT brokers (first one to connect will be used and selection is done in a round robin fashion) e.g.: `ha_hosts ["host1", "host2"]`
 - **port**: Port number of MQTT broker
 - **client_id**: Client ID that to connect to MQTT broker
 - **parser**: Parser plugin can be specified [Parser Plugin](https://docs.fluentd.org/v1.0/articles/parser-plugin-overview)
 - **topic**: Topic name to be subscribed
+- **topic_with_qos**: Topic name to be subscribed with the respective qos to be used as qos > 0(default) is preferred sometimes, e.g.: `topic_with_qos ["a/b", 1]`
 - **security**
   - **username**: User name for authentication
   - **password**: Password for authentication
@@ -84,6 +86,7 @@ The default MQTT topic is "#". Configurable options are the following:
 - **retry_inc_ratio**: An increase ratio of retry interval per connection failure (default 2 (double)). It may be better to set the value to 1 in a mobile environment for eager reconnection.
 - **max_retry_interval**: Maximum value of retry interval (default 300)
 - **max_retry_freq**: Threshold of retry frequency described by a number of retries per minutes. This option is provided for detecting failure via proxy services, e.g. ssh port forwarding. When the thresold is exceeded, MqttProxy::ExceedRetryFrequencyThresholdException is raised and the fluentd will be restarted. So, it is enough to be specified once for a MQTT server at a source/match directive in your configuration (default 10)
+- **max_ha_connect_retries**: Maximum value of retries while using ha_hosts option. This option is provided to cycle between the hosts in a round robin fashion. When the value is exceeded, MqttProxy::ExceedConnectRetryException is raised and the fluentd will be restarted. So, it is enough to be specified once for a MQTT server at a source/match directive in your configuration (default 10).
 
 Input Plugin supports @label directive.
 

--- a/fluent-plugin-mqtt-io.gemspec
+++ b/fluent-plugin-mqtt-io.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-mqtt-io"
-  spec.version       = "0.5.0"
+  spec.version       = "0.6.0"
   spec.authors       = ["Toyokazu Akiyama"]
   spec.email         = ["toyokazu@gmail.com"]
 

--- a/lib/fluent/plugin/in_mqtt.rb
+++ b/lib/fluent/plugin/in_mqtt.rb
@@ -15,6 +15,9 @@ module Fluent::Plugin
     desc 'The topic to subscribe.'
     config_param :topic, :string, default: '#'
 
+    desc 'Topic with qos to subscribe in array format ["a/b",1]'
+    config_param :topic_with_qos, :array, default: nil
+
     config_section :parse do
       desc 'The format to receive.'
       config_param :@type, :string, default: 'none'
@@ -81,7 +84,12 @@ module Fluent::Plugin
 
     def after_connection
       if @client.connected?
-        @client.subscribe(@topic)
+        if @topic_with_qos.nil?
+          @client.subscribe(@topic)
+        else
+          @client.subscribe(@topic_with_qos)
+        end
+
         @get_thread = thread_create(:in_mqtt_get) do
           @client.get do |topic, message|
             emit(topic, message)

--- a/test/plugin/test_in_mqtt.rb
+++ b/test/plugin/test_in_mqtt.rb
@@ -48,5 +48,23 @@ class MqttInputTest < Test::Unit::TestCase
       assert_equal '/cert/cert.pem', d.instance.security.tls.cert_file
 
     end
+
+    test "topic with qos" do
+      d = create_driver %[
+          topic_with_qos ["a/b",1]
+      ]
+
+      assert_equal ["a/b",1], d.instance.topic_with_qos
+
+    end
+
+    test "highly available hosts" do
+      d = create_driver %[
+          ha_hosts ["host1","host2"]
+      ]
+
+      assert_equal ["host1","host2"], d.instance.ha_hosts
+
+    end
   end
 end


### PR DESCRIPTION
Hi @toyokazu,

I've managed to implement the feature addressing [https://github.com/toyokazu/fluent-plugin-mqtt-io/issues/24](24) in addition to implementing an option which takes qos along with the topic subscription. 

Please help review and merge the changes. I am not a Ruby developer so open to feedback if code needs change :)

Many thanks